### PR TITLE
Support hub pull-request messages

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -600,7 +600,8 @@ basic structure of and errors in git commit messages."
               '(("/COMMIT_EDITMSG\\'" . git-commit-mode)
                 ("/NOTES_EDITMSG\\'" . git-commit-mode)
                 ("/MERGE_MSG\\'" . git-commit-mode)
-                ("/TAG_EDITMSG\\'" . git-commit-mode))))
+                ("/TAG_EDITMSG\\'" . git-commit-mode)
+                ("/PULLREQ_EDITMSG\\'" . git-commit-mode))))
 
 (provide 'git-commit-mode)
 


### PR DESCRIPTION
`hub pull-request`[0](https://github.com/defunkt/hub) pops an $EDITOR instance with PULLREQ_EDITMSG as the file
content. `git-commit-mode` should be able to handle this as a standard
`git-commit` type.
