### PR TITLE
Add more commit pseudo-headers

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -274,7 +274,17 @@ If the above mechanism fails, the value of the variable
     "Cc"
     "Reported-by"
     "Tested-by"
-    "Reviewed-by")
+    "Reviewed-by"
+    "Reported-and-tested-by"
+    "Helped-by"
+    "Suggested-by"
+    "Originally-by"
+    "Noticed-by"
+    "Spotted-by"
+    "Inspired-by"
+    "Based-on-patch-by"
+    "Bisected-by"
+    "Requested-by")
   "A list of git pseudo headers to be highlighted.")
 
 (defun git-commit-find-pseudo-header-position ()


### PR DESCRIPTION
Based on the common ones in linux.git and git.git.  To see them, execute
the following on linux.git and git.git:

  $ git log | grep -- -by: | sed -e 's/-by: .*//' | sort | uniq -c |
  sort -r -h | head -n 20

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
