### PR TITLE
git-rebase-mode.el: fix for incorrect function name

### DIFF
--- a/git-rebase-mode.el
+++ b/git-rebase-mode.el
@@ -336,7 +336,7 @@ running 'man git-rebase' at the command line) for details."
    (list git-rebase-dead-line-re 0 ''git-rebase-killed-action-face t))
   "Font lock keywords for Git-Rebase mode.")
 
-(defun git-rebase-show-keybindings ()
+(defun git-rebase-mode-show-keybindings ()
   "Modify the \"Commands:\" section of the comment Git generates
 at the bottom of the file so that in place of the one-letter
 abbreviation for the command, it shows the command's keybinding.


### PR DESCRIPTION
Related commit: 52e5cd0688d892e4785f27823a8a37ef1097c70d
