### PR TITLE
Support XDG_CONFIG_HOME for ignore/config mode.

### DIFF
--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -120,12 +120,7 @@ Return t if so, or nil otherwise."
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitconfig" string-end)
                        (rx "/.git/config" string-end)
-                       (rx (eval
-                            (expand-file-name
-                             "git/config"
-                             (file-name-as-directory
-                              (or (getenv "XDG_CONFIG_HOME")
-                                  "~/.config/")))) string-end)))
+                       (rx "/git/config" string-end)))
   (add-to-list 'auto-mode-alist (cons pattern 'gitconfig-mode)))
 
 (provide 'gitconfig-mode)

--- a/gitignore-mode.el
+++ b/gitignore-mode.el
@@ -55,12 +55,7 @@
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitignore" string-end)
                        (rx "/.git/info/exclude" string-end)
-                       (rx (eval (expand-file-name
-                                  "git/ignore"
-                                  (file-name-as-directory
-                                   (or (getenv "XDG_CONFIG_HOME")
-                                       "~/.config/"))))
-                           string-end)))
+                       (rx "/git/ignore" string-end)))
   (add-to-list 'auto-mode-alist (cons pattern 'gitignore-mode)))
 
 (provide 'gitignore-mode)


### PR DESCRIPTION
From git-config(1)

```
   $XDG_CONFIG_HOME/git/config
       Second user-specific configuration file. If $XDG_CONFIG_HOME is not set or empty,
       $HOME/.config/git/config will be used. Any single-valued variable set in this file
       will be overwritten by whatever is in ~/.gitconfig. It is a good idea not to
       create this file if you sometimes use older versions of Git, as support for this
       file was added fairly recently.
```

And gitignore(5)

```
       [...] Its default value is
       $XDG_CONFIG_HOME/git/ignore. If $XDG_CONFIG_HOME is either not set or empty,
       $HOME/.config/git/ignore is used instead.
```

The current implementation is specific to the user's home directory
and does not work correctly for other users.  I'm not sure what's the
best way to fix this or if this is even needed.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
