### PR TITLE
gitattributes-mode: Major mode for editing .gitattributes files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Customization
 - `git-rebase-mode`: `M-x customize-group rebase-mode`
 - `gitconfig-mode`: No customization provided.
 - `gitignore-mode`: No customization provided.
-- `gitattributes-mode`: No customization provided.
+- `gitattributes-mode`: `M-x customize-group gitattributes-mode`.
 
 
 Further help

--- a/gitattributes-mode.el
+++ b/gitattributes-mode.el
@@ -42,6 +42,13 @@
   :prefix "gitattributes-mode-"
   :group 'tools)
 
+(defcustom gitattributes-mode-enable-eldoc t
+  "Enable `eldoc-mode' when loading `gitattributes-mode'.
+This provides documentation for known variables in the echo area.
+Alternatively add `turn-on-eldoc-mode' to the mode hook."
+  :type 'boolean
+  :group 'gitattributes-mode)
+
 (defcustom gitattributes-mode-man-function #'man
   "Function to open the gitattributes(5) manpage."
   :type '(choice (const :tag "Man" #'man)
@@ -191,7 +198,9 @@ If ARG is omitted or nil, move point forward one field."
   :syntax-table gitattributes-mode-syntax-table
   (setq font-lock-defaults '(gitattributes-mode-font-lock-keywords))
   (setq-local eldoc-documentation-function #'gitattributes-mode-eldoc)
-  (setq-local forward-sexp-function #'gitattributes-mode-forward-field))
+  (setq-local forward-sexp-function #'gitattributes-mode-forward-field)
+  (when gitattributes-mode-enable-eldoc
+    (eldoc-mode 1)))
 
 ;;;###autoload
 (dolist (pattern '("/\\.gitattributes\\'"


### PR DESCRIPTION
Initial release.  So far it supports some basic syntax highlighting.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
