### PR TITLE
Support XDG_CONFIG_HOME for ignore/config mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ created by `git rebase -i`.
 
 ### `gitconfig-mode`
 
-`gitconfig-mode` is automatically enabled for `.gitconfig` and `.git/config`
-files.  The mode is derived from `conf-unix-mode`, so all commands provided by
-`conf-mode` (e.g. `conf-align-assignments`) will work as expected.
+`gitconfig-mode` is automatically enabled for `.gitconfig`, `.git/config`
+and `git/config` files.  The mode is derived from `conf-unix-mode`, so all
+commands provided by `conf-mode` (e.g. `conf-align-assignments`) will work
+as expected.
 
 ### `gitignore-mode`
 
-`gitignore-mode` is automatically enabled for `.gitignore` and
-`.git/info/exclude` files.
+`gitignore-mode` is automatically enabled for `.gitignore`,
+`.git/info/exclude` and `git/ignore` files.
 
 
 Customization

--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -119,7 +119,8 @@ Return t if so, or nil otherwise."
 
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitconfig" string-end)
-                       (rx "/.git/config" string-end)))
+                       (rx "/.git/config" string-end)
+                       (rx "/git/config" string-end)))
   (add-to-list 'auto-mode-alist (cons pattern 'gitconfig-mode)))
 
 (provide 'gitconfig-mode)

--- a/gitignore-mode.el
+++ b/gitignore-mode.el
@@ -54,7 +54,8 @@
 
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitignore" string-end)
-                       (rx "/.git/info/exclude" string-end)))
+                       (rx "/.git/info/exclude" string-end)
+                       (rx "/git/ignore" string-end)))
   (add-to-list 'auto-mode-alist (cons pattern 'gitignore-mode)))
 
 (provide 'gitignore-mode)


### PR DESCRIPTION
From git-config(1)

```
$XDG_CONFIG_HOME/git/config
   Second user-specific configuration file. If $XDG_CONFIG_HOME is not set or empty,
   $HOME/.config/git/config will be used. Any single-valued variable set in this file
   will be overwritten by whatever is in ~/.gitconfig. It is a good idea not to
   create this file if you sometimes use older versions of Git, as support for this
   file was added fairly recently.
```

And gitignore(5)

```
[...] Its default value is
$XDG_CONFIG_HOME/git/ignore. If $XDG_CONFIG_HOME is either not set or empty,
$HOME/.config/git/ignore is used instead.
```

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
