### PR TITLE
Add mode hooks to {git-commit,gitconfig,gitignore}-mode

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -144,6 +144,9 @@ confirmation before committing."
   "Hook run by `git-commit-commit' unless clients exist.
 Only use this if you know what you are doing.")
 
+(defvar git-commit-mode-hook nil
+  "List of functions to be called when activating `git-commit-mode'.")
+
 (defun git-commit-commit (&optional force)
   "Finish editing the commit message and commit.
 
@@ -511,7 +514,9 @@ basic structure of and errors in git commit messages."
        (concat paragraph-start "\\|*\\|("))
   ;; Do not remember point location in commit messages
   (when (fboundp 'toggle-save-place)
-    (toggle-save-place 0)))
+    (toggle-save-place 0))
+  ;; Run any user-defined hooks as the last thing we do.
+  (run-mode-hooks 'git-commit-mode-hook))
 
 ;;;###autoload
 (dolist (pattern '("/COMMIT_EDITMSG\\'" "/NOTES_EDITMSG\\'"

--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -108,6 +108,9 @@ Return t if so, or nil otherwise."
           word-end (zero-or-more (syntax whitespace)) line-end)
      (1 'font-lock-constant-face))))
 
+(defvar gitconfig-mode-hook nil
+  "List of functions to be called when activating `gitconfig-mode'.")
+
 ;;;###autoload
 (define-derived-mode gitconfig-mode conf-unix-mode "Gitconfig"
   "A major mode for editing .gitconfig files."
@@ -115,7 +118,9 @@ Return t if so, or nil otherwise."
   (conf-mode-initialize "#" gitconfig-mode-font-lock-keywords)
   (setq indent-tabs-mode t)
   (set (make-local-variable 'indent-line-function)
-       'gitconfig-indent-line))
+       'gitconfig-indent-line)
+  ;; Run any user-defined hooks as the last thing we do.
+  (run-mode-hooks 'gitconfig-mode-hook))
 
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitconfig" string-end)

--- a/gitignore-mode.el
+++ b/gitignore-mode.el
@@ -32,6 +32,9 @@
 (require 'rx)
 (require 'conf-mode)
 
+(defvar gitignore-mode-hook nil
+  "List of functions to be called when activating `gitignore-mode'.")
+
 (defvar gitignore-mode-font-lock-keywords
   `((,(rx line-start (syntax comment-start) (zero-or-more not-newline) line-end)
      . 'font-lock-comment-face)
@@ -50,7 +53,9 @@
   ;; Disable syntactic font locking, because comments are only valid at
   ;; beginning of line.
   (setq font-lock-defaults '(gitignore-mode-font-lock-keywords t t))
-  (set (make-local-variable 'conf-assignment-sign) nil))
+  (set (make-local-variable 'conf-assignment-sign) nil)
+  ;; Run any user-defined hooks as the last thing we do.
+  (run-mode-hooks 'gitignore-mode-hook))
 
 ;;;###autoload
 (dolist (pattern (list (rx "/.gitignore" string-end)


### PR DESCRIPTION
I only actually needed this for the git-commit-mode, because I wanted to
turn off the annoying auto-fill, I prefer to do it myself, and sometimes
you want long lines for e.g. quoting log output.

So now you can do that like:

```
(add-hook 'git-commit-mode-hook
          '(lambda ()
             (message "Running the git commit mode hook")
             (turn-off-auto-fill)))
```

I didn't add a git-rebase-mode-hook because it's already here in some
form, although I don't understand how it's supposed to work:

```
$ git --no-pager grep git-rebase-mode-hook
git-rebase-mode.el:362:(add-hook 'git-rebase-mode-hook 'git-rebase-mode-show-keybindings t)
git-rebase-mode.el:367:(add-hook 'git-rebase-mode-hook 'git-rebase-mode-disable-before-save-hook)
```
