### PR TITLE
Usability fixes

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -325,7 +325,7 @@ use for fontification.")
    ;; Skip empty lines or comments before the summary
    (zero-or-more
     line-start
-    (or (one-or-more (syntax whitespace))
+    (or (zero-or-more (syntax whitespace))
         (and (syntax comment-start) (zero-or-more not-newline)))
     "\n")
    ;; The actual summary line


### PR DESCRIPTION
To test commit `Fix matching of empty lines before summary`:
Enter a few newlines before the commit summary and notice the broken highlighting.
