### PR TITLE
Revert "git-commit-insert-header-as-self: stop using some env vars"

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -262,9 +262,12 @@ Also see `git-commit-insert-header'."
   (git-commit-insert-header
    type
    (or (getenv "GIT_AUTHOR_NAME")
+       (getenv "GIT_COMMITTER_NAME")
        (ignore-errors (car (process-lines "git" "config" "user.name")))
        user-full-name)
    (or (getenv "GIT_AUTHOR_EMAIL")
+       (getenv "GIT_COMMITTER_EMAIL")
+       (getenv "EMAIL")
        (ignore-errors (car (process-lines "git" "config" "user.email")))
        user-mail-address)))
 


### PR DESCRIPTION
From the git-commit-tree(1) man page:
  #+begin_quote
    While parent object ids are provided on the command line,
    author and committer information is taken from the following
    environment variables, if set:

```
    GIT_AUTHOR_NAME
    GIT_AUTHOR_EMAIL
    GIT_AUTHOR_DATE
    GIT_COMMITTER_NAME
    GIT_COMMITTER_EMAIL
    GIT_COMMITTER_DATE
    EMAIL

In case (some of) these environment variables are not set,
the information is taken from the configuration items
user.name and user.email, or, if not present, system user
name and the hostname used for outgoing mail (taken from
/etc/mailname and falling back to the fully qualified
hostname when that file does not exist).
```

  #+end_quote

This reverts commit 61a6e94d399dd53fe0a56dd12bbe7184f9915b48.

Signed-off-by: Pieter Praet pieter@praet.org
