### PR TITLE
`git-rebase-show-commit': run `magit-show-commit' in correct `default-directory'

### DIFF
--- a/git-rebase-mode.el
+++ b/git-rebase-mode.el
@@ -309,7 +309,8 @@ exec line was commented out, also uncomment it."
     (when (looking-at git-rebase-action-line-re)
       (let ((commit (match-string 2)))
         (if (fboundp 'magit-show-commit)
-            (magit-show-commit commit nil nil 'select)
+            (let ((default-directory (expand-file-name "../../")))
+              (magit-show-commit commit nil nil 'select))
           (shell-command (concat "git show " commit)))))))
 
 (defun git-rebase-backward-line (&optional n)


### PR DESCRIPTION
To find out the correct `default-directory' in which to initialize
`magit-commit-mode', `magit-show-commit' uses`magit-get-top-dir',
which uses "git rev-parse --show-cdup".

Unfortunately, that command doesn't return anything when run from
within (a subdir of) $GIT_DIR like e.g. "<repo>/.git/rebase-merge/",
causing subsequent commands in `magit-refresh-commit-buffer' to fail.

Fix it by setting `default-directory' to the current dir's grandparent
before invoking`magit-show-commit'.

Fixes #44.

Signed-off-by: Pieter Praet pieter@praet.org
