### PR TITLE
Fixes

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -471,7 +471,7 @@ basic structure of and errors in git commit messages."
        (concat paragraph-start "\\|*\\|("))
   ;; Do not remember point location in commit messages
   (when (fboundp 'toggle-save-place)
-    (toggle-save-place 0)))
+    (setq save-place nil)))
 
 ;;;###autoload
 (dolist (pattern '("/COMMIT_EDITMSG\\'" "/NOTES_EDITMSG\\'"


### PR DESCRIPTION
1. `Fix highlighting of non-empty second line` fixes an error that was just introduced in https://github.com/magit/git-modes/commit/f230bb7ea85dd642c55d7fd6101428abb9eaac53
2. To test commit `Fix matching of empty lines before summary`:
   Enter a few newlines before the commit summary and notice the broken highlighting.
