### PR TITLE
Fixes

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -325,7 +325,7 @@ use for fontification.")
 (defun git-commit-build-summary-regexp (max-summary-col)
   (concat
    ;; Skip empty lines or comments before the summary
-   "\\`\\(?:^\\(?:\\s-+\\|\\s<.*\\)\n\\)*"
+   "\\`\\(?:^\\(?:\\s-*\\|\\s<.*\\)\n\\)*"
    ;; The summary line
    (format "\\(.\\{0,%d\\}\\)\\(.*\\)" max-summary-col)
    ;; Non-empty non-comment second line


### PR DESCRIPTION
1. `Fix highlighting of non-empty second line` and `Fix highlighting of summary lines without trailing newlines` fix bugs that were just introduced in https://github.com/magit/git-modes/commit/f230bb7ea85dd642c55d7fd6101428abb9eaac53
2. To test commit `Fix matching of empty lines before summary`:
   Enter a few newlines before the commit summary and notice the broken highlighting.
