### PR TITLE
README.md: backtick quote ".gitattributes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Features
   `.gitconfig` files.
 - `gitignore-mode` – A `conf-mode`-derived major mode for editing `.gitignore`
   files.
-- `gitattributes-mode` – A major mode for editing .gitattributes files.
+- `gitattributes-mode` – A major mode for editing `.gitattributes` files.
 
 The first two modes integrate into [Magit][2].
 


### PR DESCRIPTION
Wrap ".gitattributes" in Markdown code span, like we do for all filenames.

See commit 8bec7bc7.

Signed-off-by: Pieter Praet pieter@praet.org
