### PR TITLE
`git-rebase-mode-map': fix docstring typo fix

### DIFF
--- a/git-rebase-mode.el
+++ b/git-rebase-mode.el
@@ -128,9 +128,7 @@
     (define-key map (kbd "M-p") 'git-rebase-move-line-up)
     (define-key map (kbd "M-n") 'git-rebase-move-line-down)
     map)
-  "Keymap for Git-Rebase mode.
-Note that this will be added to the top-level code which defines
-the edit functions.")
+  "Keymap for Git-Rebase mode.")
 
 (easy-menu-define git-rebase-mode-menu git-rebase-mode-map
   "Git-Rebase mode menu"


### PR DESCRIPTION
Commit af96de0e assumed `git-rebase-mode-map's docstring contained
a typo, but it turns out that it was just worded awkwardly.

But instead of reverting that commit, remove the line entirely,
as the code which used to add the keybinds for git-rebase-{pick,...}
to `git-rebase-mode-map' was removed in commit cb15fbe2...

Signed-off-by: Pieter Praet pieter@praet.org
