### PR TITLE
git-commit-mode.el: remove 'saveplace dependency

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -61,8 +61,9 @@
 
 ;;; Code:
 
-(require 'saveplace)
 (require 'server)
+
+(defvar save-place)
 
 (defgroup git-commit nil
   "Mode for editing git commit messages"
@@ -479,7 +480,7 @@ basic structure of and errors in git commit messages."
   (set (make-local-variable 'paragraph-start)
        (concat paragraph-start "\\|*\\|("))
   ;; Do not remember point location in commit messages
-  (when (fboundp 'toggle-save-place)
+  (when save-place
     (setq save-place nil)))
 
 ;;;###autoload


### PR DESCRIPTION
The only reason we required 'saveplace was to get rid of a
byte-compilation warning (assignment to free variable `save-place'),
i.e. we don't actually use any of its functionality.

Declaring `save-place' ourselves is sufficient for those purposes.

While we're at it, let's save a function call by just checking whether
`save-place' is non-nil instead of whether`toggle-save-place' has a
function definition.

See commits f5b36db4 and 830b538b.

Signed-off-by: Pieter Praet pieter@praet.org
