### PR TITLE
don't require saveplace

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -63,7 +63,6 @@
 
 (require 'log-edit)
 (require 'ring)
-(require 'saveplace)
 (require 'server)
 
 ;;; Options
@@ -555,7 +554,7 @@ basic structure of and errors in git commit messages."
   ;; Treat lines starting with a hash/pound as comments
   (set (make-local-variable 'comment-start) "#")
   ;; Do not remember point location in commit messages
-  (when (fboundp 'toggle-save-place)
+  (when (boundp 'save-place)
     (setq save-place nil))
   ;; If the commit summary is empty, insert a newline after point
   (when (string= "" (buffer-substring-no-properties


### PR DESCRIPTION
If the user hasn't setup saveplace in their config, requiring saveplace
causes them to get a useless .emacs-places in the home directory. To
avoid triggering a compilation warning, we check if `save-place` is
bound.

f5b36db4 had changed from calling `toggle-save-place` to setting
`save-place` but still checked if `toggle-save-place` was fbound,
830b538b then required saveplace to quiet the compiler.
