### PR TITLE
`gitconfig-indent-line': compare `char-after' with `[' using `equal'

### DIFF
--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -63,7 +63,7 @@ Return t if so, or nil otherwise."
           (was-in-indent (gitconfig-point-in-indentation-p)))
       (beginning-of-line)
       (delete-horizontal-space)
-      (unless (= (char-after) ?\[)
+      (unless (equal (char-after) ?\[)
         (insert-char ?\t 1))
       (if was-in-indent
           (back-to-indentation)


### PR DESCRIPTION
Calling `newline-and-indent' with point being @`point-max' resulted in
a `wrong-type-argument' error due to`gitconfig-indent-line' trying to
compare `char-after's return value (which is nil @ eob) to`[' using
`=', which expects both of its arguments to be numbers or markers.

Signed-off-by: Pieter Praet pieter@praet.org
