### PR TITLE
tell newcomment.el # is only comment at line start (v2)

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -554,6 +554,10 @@ basic structure of and errors in git commit messages."
        (concat paragraph-start "\\|*\\|("))
   ;; Treat lines starting with a hash/pound as comments
   (set (make-local-variable 'comment-start) "#")
+  (set (make-local-variable 'comment-start-skip)
+       (concat "^" (regexp-quote comment-start) "+"
+               "\\s-*"))
+  (set (make-local-variable 'comment-use-syntax) nil)
   ;; Do not remember point location in commit messages
   (when (fboundp 'toggle-save-place)
     (setq save-place nil))


### PR DESCRIPTION
Otherwise we get things like this:

```
A typical commit message referencing issue #xxx that is long enough to
                                           #need filling,
```

This is not related to fontifying of comments which already applies only
to lines beginning with `#`. It's also not related to the syntax-table;
middle of line `#`s still have comment syntax, but apparently this has no
effect.

Fixes #67.
