### PR TITLE
don't save comments in commit message

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -341,17 +341,13 @@ before any trailing comments git or the user might have
 inserted."
   (save-excursion
     (goto-char (point-max))
-    (if (not (re-search-backward "^\\S<.+$" nil t))
-        ;; no comment lines anywhere before end-of-buffer, so we
-        ;; want to insert right there
-        (point-max)
-      ;; there's some comments at the end, so we want to insert before
-      ;; those; keep going until we find the first non-empty line
-      ;; NOTE: if there is no newline at the end of (point),
-      ;; (forward-line 1) will take us to (point-at-eol).
-      (if (eq (point-at-bol) (point-at-eol)) (re-search-backward "^.+$" nil t))
-      (forward-line 1)
-      (point))))
+    (if (re-search-backward "^[^#\n]" nil t)
+        ;; we found last non-empty non-comment line, headers go after
+        (forward-line 1)
+      ;; there's only blanks & comments, headers go before comments
+      (goto-char (point-min))
+      (and (re-search-forward "^#" nil t) (forward-line 0)))
+    (point)))
 
 (defun git-commit-determine-pre-for-pseudo-header ()
   "Find the characters to insert before the pseudo header.


### PR DESCRIPTION
The comment lines are auto generated by git, so there is no point in saving them; it's often confusing to see the old list of changes-to-be-committed that doesn't correspond to the current commit.

---
###### Possible concern:

This could lose some info if the user puts a trailing comment themselves. I don't think that's worth coding for as there is no benefit (that I can think of) to writing manual comments in a commit message.
