### PR TITLE
ring-index must be non-nil if we saved a message

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -326,6 +326,9 @@ The commit message is saved to the kill ring."
     (when (and (string-match "^\\s-*\\sw" message)
                (or (ring-empty-p log-edit-comment-ring)
                    (not (ring-member log-edit-comment-ring message))))
+      ;; if index is nil, we end up cycling back to message we just saved!
+      (unless log-edit-comment-ring-index
+        (setq log-edit-comment-ring-index 0))
       (ring-insert log-edit-comment-ring message))))
 
 (defun git-commit-prev-message (arg)

--- a/tests/git-commit-tests.el
+++ b/tests/git-commit-tests.el
@@ -51,16 +51,14 @@
 
 (ert-deftest git-commit-message-history-leave-comments ()
   "History cycling commands should not affect comments"
-  (flet ((git-commit-save-message () nil)) ;ignore issue #75
-    (git-commit-with-temp-message-history
-     (insert "current msg\n\n#comment")
-     (git-commit-prev-message 1)
-     (should (equal (buffer-string) "msg three\n\n#comment")))))
+  (git-commit-with-temp-message-history
+   (insert "current msg\n\n#comment")
+   (git-commit-prev-message 1)
+   (should (equal (buffer-string) "msg three\n\n#comment"))))
 
 (ert-deftest git-commit-message-history-leave-comments-empty ()
   "History cycling commands should not affect comments, start from empty message."
-  (flet ((git-commit-save-message () nil)) ;ignore issue #75
-    (git-commit-with-temp-message-history
-     (insert "\n\n#comment")
-     (git-commit-prev-message 1)
-     (should (equal (buffer-string) "msg three\n\n#comment")))))
+  (git-commit-with-temp-message-history
+   (insert "\n\n#comment")
+   (git-commit-prev-message 1)
+   (should (equal (buffer-string) "msg three\n\n#comment"))))


### PR DESCRIPTION
When ring-index is nil, log-edit-previous-comment goes to the "last"
item, which turns out to be the current message that has just been
saved, i.e. the message in buffer does not change.

---

Half fixes #75 (and I'm giving up on the other half).
