### PR TITLE
git-commit-mode.el: abort cleanly when git process disappears

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -302,8 +302,9 @@ The commit message is saved to the kill ring."
     (let ((clients (git-commit-buffer-clients)))
       (if clients
           (dolist (client clients)
-            (server-send-string client "-error Commit aborted by user")
-            (delete-process client))
+            (when (eq (process-status client) 'run)
+              (server-send-string client "-error Commit aborted by user")
+              (delete-process client)))
         (kill-buffer))))
   (message (concat "Commit aborted."
                    (when (memq 'git-commit-save-message


### PR DESCRIPTION
We currently don't handle the case where the underlying git process
disappears from underneath us while editing our commit message. Fix this
since magit now supports killing individual running git
processes (including the `git commit' process that git-commit-mode
currently relies on).
