### PR TITLE
Do not enable flyspell-mode by default

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -84,7 +84,7 @@ confirmation before committing."
   :type '(choice (const :tag "On style errors" t)
                  (const :tag "Never" nil)))
 
-(defcustom git-commit-mode-hook '(turn-on-auto-fill flyspell-mode)
+(defcustom git-commit-mode-hook '(turn-on-auto-fill)
   "Hook run when entering Git Commit mode."
   :options '(turn-on-auto-fill flyspell-mode git-commit-save-message)
   :type 'hook


### PR DESCRIPTION
Flyspell is probably too intrusive to be enabled by default.
Functionally it also depends on system's spell-checker configuration
which is outside of the scope of Git commit mode.

Signed-off-by: Teemu Likonen tlikonen@iki.fi
