### PR TITLE
git-commit-mode.el: avoid extra newlines after existing pseudo-headers

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -355,6 +355,16 @@ With a numeric prefix ARG, go forward ARG comments."
 
 ;;; Headers
 
+(defun git-commit-prev-line-is-pseudo-header-p ()
+  "Whether we're on the line immediately following existing
+pseudo headers."
+  (save-excursion
+    (forward-line -1)
+    ;; until we can use -any? from dash :(
+    (first (member t (mapcar (lambda (hdr)
+                               (looking-at-p (regexp-quote (concat hdr ":"))))
+                             git-commit-known-pseudo-headers)))))
+
 (defun git-commit-find-pseudo-header-position ()
   "Find the position at which commit pseudo headers should be inserted.
 
@@ -369,7 +379,8 @@ inserted."
       ;; there's only blanks & comments, headers go before comments
       (goto-char (point-min))
       (and (re-search-forward "^#" nil t) (forward-line 0)))
-    (skip-chars-forward "\n")
+    (unless (git-commit-prev-line-is-pseudo-header-p)
+      (skip-chars-forward "\n")) 
     (point)))
 
 (defun git-commit-determine-pre-for-pseudo-header ()


### PR DESCRIPTION
Currently, if you are adding a psuedo-header to a commit that already
has a block of psuedo-headers you get an extra newline after the
existing pseudo-header block and your new pseudo-header. For example,
given the following commit message:

```
.mailmap: map different names with the same email address

Pretty much one year ago (94b410bba864, Jul 12 2013, .mailmap: Map
email addresses to names) I cleaned up the output of `git shortlog
-sne` of git.git by writing a .mailmap file fot the git.git project.

During the year Jens, Kazuki and Trần contributed to git.git using
different names, but the same email address; unify them.

Signed-off-by: Stefan Beller <stefanbeller@googlemail.com>
Signed-off-by: Junio C Hamano <gitster@pobox.com>
```

If I was importing that into my repository and adding my SOB to it,
currently I would get the following after doing a `git-commit-signoff':

```
.mailmap: map different names with the same email address

Pretty much one year ago (94b410bba864, Jul 12 2013, .mailmap: Map
email addresses to names) I cleaned up the output of `git shortlog
-sne` of git.git by writing a .mailmap file fot the git.git project.

During the year Jens, Kazuki and Trần contributed to git.git using
different names, but the same email address; unify them.

Signed-off-by: Stefan Beller <stefanbeller@googlemail.com>
Signed-off-by: Junio C Hamano <gitster@pobox.com>

Signed-off-by: Mitchel Humpherys <mitch.special@gmail.com>
```

After this change, I get:

```
.mailmap: map different names with the same email address

Pretty much one year ago (94b410bba864, Jul 12 2013, .mailmap: Map
email addresses to names) I cleaned up the output of `git shortlog
-sne` of git.git by writing a .mailmap file fot the git.git project.

During the year Jens, Kazuki and Trần contributed to git.git using
different names, but the same email address; unify them.

Signed-off-by: Stefan Beller <stefanbeller@googlemail.com>
Signed-off-by: Junio C Hamano <gitster@pobox.com>
Signed-off-by: Mitchel Humpherys <mitch.special@gmail.com>
```

which is consistent with using git-commit's `-s' switch directly.
