### PR TITLE
Fix font-locking of action and file

### DIFF
--- a/git-commit-mode.el
+++ b/git-commit-mode.el
@@ -535,7 +535,7 @@ Known comment headings are provided by `git-commit-comment-headings'."
   (append
    `(("^\\s<.*$" . 'font-lock-comment-face)
      ("^\\s<\\s-On branch \\(.*\\)$" (1 'git-commit-branch-face t))
-     ("^\\s<\t\\(?:\\([^:]+\\):\\s-+\\)?\\(.*\\)$"
+     ("^\\s<\t\\(?:\\([^:\n]+\\):\\s-+\\)?\\(.*\\)$"
       (1 'git-commit-comment-action-face t t)
       (2 'git-commit-comment-file-face t))
      (,(concat "^\\("


### PR DESCRIPTION
This patch changes the regular expression that is supposed to match the
lines containing "modified:" or "some-file.txt" in the example below. It
is desirable that this regexp does not match multiple lines.

```
#       modified:   git-commit-mode.el
#
# Untracked files:
#       some-file.txt
```

The reason is that if the commit message contains a diff (i.e. "git
commit -v" was run) the "[^:]:" regexp can match multiple lines if there
is a colon in the diff. In the example above, the match would span from
'some-file.txt' up to the colon in the diff. This results in overriding
the font-locking in the diff.

Signed-off-by: Michal Sojka sojkam1@fel.cvut.cz
