### PR TITLE
Allow blank lines when highlighting first field

### DIFF
--- a/gitattributes-mode.el
+++ b/gitattributes-mode.el
@@ -141,6 +141,8 @@ If NO-STATE is non-nil then do not print state."
      (let ((old-limit limit))
        (save-excursion
          (beginning-of-line)
+         (while (looking-at "^\\s-*$")
+           (forward-line))
          (when (re-search-forward "[[:space:]]" limit 'noerror)
            (setq limit (point))))
        (unless (< limit (point))


### PR DESCRIPTION
Before, the first field after a blank line would not be
highlighted (e.g., the '*' in front of '.lisp' below).

```
*.html   diff=html

*.lisp   diff=lisp
*.el     diff=lisp
```
