### PR TITLE
don't use EMACS environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-EMACS  ?= emacs
+EMACS_BIN  ?= emacs
 EFLAGS ?=
-BATCH   = $(EMACS) $(EFLAGS) -batch -Q -L .
+BATCH   = $(EMACS_BIN) $(EFLAGS) -batch -Q -L .
 BATCHE  = $(BATCH) -eval
 BATCHC  = $(BATCH) -f batch-byte-compile
 
@@ -20,7 +20,7 @@ clean:
 	@rm -f $(ELCS)
 
 %.elc: %.el
-	@$(BATCHC) $<
+	$(BATCHC) $<
 
 .PHONY: test
 test:


### PR DESCRIPTION
The EMACS environment variable is usually defined by tramp to the value "t".
Replace the variable name with EMACS_BIN to avoid build failure.
