### PR TITLE
with-editor review

### DIFF
--- a/with-editor.el
+++ b/with-editor.el
@@ -500,9 +500,7 @@ This works in `shell-mode', `term-mode' and `eshell-mode'."
     (let ((process (get-buffer-process (current-buffer)))
           (editor (format "export %s=%s"
                           envvar
-                          (shell-quote-argument
-                           (let ((with-editor-emacsclient-executable nil))
-                             (with-editor (getenv envvar)))))))
+                          (shell-quote-argument with-editor-looping-editor))))
       ;; Both comint & term use processes
       (with-editor-process-send-string-silently process editor)
 


### PR DESCRIPTION
Hello,

As usual it's likely that more commits will follow based on the discussion.
1. [DONE] What do you think about this commit (moving eshell in "right" place)?
2. [DONE] I added a todo item in #113, namely the one about `eshell-preoutput-filter-functions` which is never cleaned. `eshell` has an exit hook that we could use to cleanup, what do you think? Should we care? For `shell` we don't care because the local add-hook dies with the shell buffer, same story for `term`. By the way `shell` & `term` could actually share the same implementation I think (comint just wraps a process, while eshell works differently).
3. [DONE] All the "invisible" commands TODO items are not really solvable without some filtering pain, which makes me think it's much easier to add a `echo with-editor ready for EDITOR` at the end of what we insert in the buffer. Possibly with a `clear` before so it looks neat. What do you think?
