### PR TITLE
Improve indentation in gitconfig-mode (second try)

### DIFF
--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -40,9 +40,10 @@
                         symbol-start
                         (minimal-match (zero-or-more not-newline))
                         symbol-end "]"))
-        (looking-at (rx line-start "\t"
-                        symbol-start (or (syntax word)
-                                         (syntax symbol))))
+        (looking-at (concat (rx line-start)
+                            (gitconfig-indentation-string)
+                            (rx symbol-start (or (syntax word)
+                                                 (syntax symbol)))))
         (looking-at "#")
         (looking-at (rx line-end)))))
 
@@ -62,10 +63,15 @@
       (beginning-of-line)
       (delete-horizontal-space)
       (unless (looking-at (rx (or "#" "[" line-end)))
-        (insert-char ?\t 1))
+        (insert (gitconfig-indentation-string)))
       (if was-in-indent
           (back-to-indentation)
         (goto-char (marker-position old-point))))))
+
+(defun gitconfig-indentation-string ()
+  (if indent-tabs-mode
+      "\t"
+    (make-string tab-width ?\ )))
 
 (defvar gitconfig-mode-syntax-table
   (let ((table (make-syntax-table conf-unix-mode-syntax-table)))
@@ -111,7 +117,6 @@
   "A major mode for editing .gitconfig files."
   ;; .gitconfig is indented with tabs only
   (conf-mode-initialize "#" gitconfig-mode-font-lock-keywords)
-  (setq indent-tabs-mode t)
   (set (make-local-variable 'indent-line-function)
        'gitconfig-indent-line))
 

--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -42,7 +42,9 @@
                         symbol-end "]"))
         (looking-at (rx line-start "\t"
                         symbol-start (or (syntax word)
-                                         (syntax symbol)))))))
+                                         (syntax symbol))))
+        (looking-at "#")
+        (looking-at (rx line-end)))))
 
 (defun gitconfig-point-in-indentation-p ()
   "Return if the point is in the indentation of the current line."
@@ -59,7 +61,7 @@
           (was-in-indent (gitconfig-point-in-indentation-p)))
       (beginning-of-line)
       (delete-horizontal-space)
-      (unless (equal (char-after) ?\[)
+      (unless (looking-at (rx (or "#" "[" line-end)))
         (insert-char ?\t 1))
       (if was-in-indent
           (back-to-indentation)

--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -52,12 +52,14 @@
   (save-excursion
     (let ((pos (point)))
       (back-to-indentation)
-      (< pos (point)))))
+      (<= pos (point)))))
 
 (defun gitconfig-indent-line ()
   "Indent the current line."
   (interactive)
-  (unless (gitconfig-line-indented-p)
+  (if (gitconfig-line-indented-p)
+      (when (gitconfig-point-in-indentation-p)
+        (back-to-indentation))
     (let ((old-point (point-marker))
           (was-in-indent (gitconfig-point-in-indentation-p)))
       (beginning-of-line)

--- a/gitconfig-mode.el
+++ b/gitconfig-mode.el
@@ -68,7 +68,8 @@
         (insert (gitconfig-indentation-string)))
       (if was-in-indent
           (back-to-indentation)
-        (goto-char (marker-position old-point))))))
+        (goto-char (marker-position old-point)))
+      (set-marker old-point nil))))
 
 (defun gitconfig-indentation-string ()
   (if indent-tabs-mode


### PR DESCRIPTION
This is the same change as in a previous pull request but this time it is split up in 4 commits.
The split was requested by tarsius. 
(I should probably have reused the first pull request.  Sorry for the confusion.)
Regards,
/Johan