### PR TITLE
Fix infinite-loop issue

### DIFF
--- a/gitattributes-mode.el
+++ b/gitattributes-mode.el
@@ -141,7 +141,7 @@ If NO-STATE is non-nil then do not print state."
      (let ((old-limit limit))
        (save-excursion
          (beginning-of-line)
-         (while (looking-at "^\\s-*$")
+         (while (and (not (eobp)) (looking-at "^\\s-*$"))
            (forward-line))
          (when (re-search-forward "[[:space:]]" limit 'noerror)
            (setq limit (point))))


### PR DESCRIPTION
If cursor is end-of-buffer, then infinite-loop occurs.

This is related to https://github.com/syl20bnr/spacemacs/issues/5317
CC: @datafux @StreakyCobra 