### PR TITLE
Fix bug with .gitignore extension detection

### DIFF
--- a/gitignore-mode.el
+++ b/gitignore-mode.el
@@ -48,7 +48,7 @@
   (set (make-local-variable 'conf-assignment-sign) nil))
 
 ;;;###autoload
-(dolist (pattern (list "/\\.gitignore\\'"
+(dolist (pattern (list "\\.gitignore.*\\'"
                        "/info/exclude\\'"
                        "/git/ignore\\'"))
   (add-to-list 'auto-mode-alist (cons pattern 'gitignore-mode)))


### PR DESCRIPTION
Currently the gitignore file extension regex detects if the extension starts with a slash, which of course no file extension extracted by emacs ever does. This patch fixes it. In addition, this patch also recognize gitignore file conventions such as .gitignore_global, as created by SourceTree.