### PR TITLE
Highlight comments properly

### DIFF
--- a/gitignore-mode.el
+++ b/gitignore-mode.el
@@ -33,7 +33,7 @@
 (require 'conf-mode)
 
 (defvar gitignore-mode-font-lock-keywords
-  '(("^\\s<.*$"   . font-lock-comment-face)
+  '(("^#.*$"      . font-lock-comment-face)
     ("^!"         . font-lock-negation-char-face) ; Negative pattern
     ("/"          . font-lock-constant-face)      ; Directory separators
     ("[*?]"       . font-lock-keyword-face)       ; Glob patterns


### PR DESCRIPTION
I am really not sure what is up with that weird regex that you guys use to
syntax-highlight comments, but to quote the git docs on the .gitignore file:

“A line starting with # serves as a comment.  Put a backslash (‘\’) in front of
the first hash for patterns that begin with a hash.”

There shouldn’t be any valid comment in a .gitignore besides a ‘#’ at the start
of a line.
